### PR TITLE
Fix SDS table and data

### DIFF
--- a/docs/assets/tables/sds.csv
+++ b/docs/assets/tables/sds.csv
@@ -1,65 +1,65 @@
-sku,product_name,brand,category,revision_date,pdf_path
-,Barrier,manufacturer for specific information. Other : No dat a available.,,2020-06-01,sds/Barrier SDS 6.20.pdf
-,Break Wall,,,2024-09-04,sds/Break Wall SDS 9.24.pdf
-,Cyclone,manufacturer for specific information.  Other :,,2024-09-04,sds/Cyclone SDS 9.24.pdf
-,Enviro Bio Cleaner Restorer,"supplier of the safety data sheet ENVIRO BIO  CLEANER 5118 TAWNY LAKE PL â€“ FAIRFIELD, CA 94534",,2020-09-03,sds/EBC-Restore-SDS-September-2020-1.pdf
-,Hurricane CAT 4 Part A,1-800-537-8990,,2024-09-04,sds/Hurricane CAT 4 SDS A and B 9.24.pdf
-,Hurricane CAT 5 Part A,1-800-537-8990,,2024-09-04,sds/Hurricane CAT 5 SDS A and B 9.24.pdf
-,Jetty,,,2024-09-04,sds/Jetty SDS 9.24.pdf
-,Point Break,,,2024-09-04,sds/Point Break SDS 9.24.pdf
-,Rip Tide,,,2024-09-04,sds/Rip Tide SDS 9.24.pdf
-,ABF Restoration,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS-ABF-RESTORATION.pdf
-,Alkaline Stone Cleaner,"Manufacturer s Address: EaCo Chem, Inc. 765 Comm erce Avenue",,2023-03-30,sds/SDS-Alkaline-Stone-Cleaner.pdf
-,Bleach Magic,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,NaT,sds/SDS-Bleach-Magic-2025.pdf
-,BARC,Product Name:,,2022-03-23,sds/SDS-F9-BARC-2022.pdf
-,DOUBLE EAGLE,Product Name:,,2022-03-23,sds/SDS-F9-Double-Eagle-2022.pdf
-,EFFLORESCENCE,Product Name:,,2022-03-23,sds/SDS-F9-Efflorescence-2022.pdf
-,GROUNDSKEEPER,Product Name:,,2022-03-23,sds/SDS-F9-Groundskeeper-2022.pdf
-,AcrylicStrip,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_ACRYLICSTRIP.pdf
-,AP PLUS BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_AP_PLUS_BC.pdf
-,,,,,sds/SDS_Bleach-Magic.pdf
-,Cleansol BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_CLEANSOL_BC.pdf
-,C-TAR MELT,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_CTARMELT.pdf
-,CT WASH,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_CTWASH.pdf
-,CALCITE PRESOAK,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_Calcite_Presoak.pdf
-,,,,,sds/SDS_Calcium-Silicate-Cleaner.pdf
-,DAZZLE BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_DAZZLE_BC.pdf
-,EC 101 WB,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2017-10-01,sds/SDS_EC_101_WB.pdf
-,EC102 SOL,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2022-03-28,sds/SDS_EC_102_SOL.pdf
-,EF-FORTLESS,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_EF-FORTLESS.pdf
-,Glory Truckwash BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_GLORY_TW_BC.pdf
-,Graf-Ex,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_GRAFX.pdf
-,.................... CWB Gold Assassin RTU,.............................. Clean Wash Bay Solutions,,,sds/SDS_GoldAssassinRTU.pdf
-,HD Britenol,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_HD_BRITENOL.pdf
-,HD DEGREASER,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_HD_DEGREASER.pdf
-,HD Sabre,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_HD_SABRE.pdf
-,"Heritage Restorer, (Advanced Formula)","Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_HERITAGE_RESTORER.pdf
-,HOT STAIN REMOVER,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_HOTSTAINREMOVER.pdf
-,InStrip Page: 1 of 7,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_INSTRIP.pdf
-,LCS,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_LCS.pdf
-,NMD 80,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_NMD80.pdf
-,ONERESTORE,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_ONERESTORE.pdf
-,PLUS,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_PLUS.pdf
-,Polished Stone Cleaner,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_POLISHEDSTONECLEANER.pdf
-,RS-10 BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-17,sds/SDS_RS10BC.pdf
-,Sabre II Page: 1 of 7,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_SABRE_2.pdf
-,Smoke Melt,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_SMOKE_MELT.pdf
-,"SOS 50, Advanced Formula, Aug 2017","Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_SOS50.pdf
-,Stripsol LO,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_STRIPSOL_LO.pdf
-,Supreme BC,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_SUPREME_BC.pdf
-,Stripper Cream,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_Stripper_Cream.pdf
-,TAGAWAYÂ®,"Manufacturer â€™s Name:   Equipment Trade Service Co. Inc.  Address:   20 East Winona Avenue  Norwood, PA 19074 USA",,,sds/SDS_Tagaway.pdf
-,TAGINATORÂ®,"Manufacturer â€™s Name:   Equipment Trade Service Co. Inc.  Address:   20 East Winona Avenue  Norwood, PA 19074 USA",,,sds/SDS_Taginator.pdf
-,WHITE SCUM PRESOAK,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/SDS_White-Scum-Presoak-.pdf
-,,Emergency Telephone Number,,,sds/SDS_glide-window-cleaning-soap.pdf
-,Enviro Bio Cleaner,"supplier of the safety data sheet ENVIRO BIO  CLEANER 5118 TAWNY LAKE PL â€“ FAIRFIELD, CA 94534",,2019-03-09,sds/SDS_multipurpose-cleaner.pdf
-,Safe Harbor,,,2024-09-04,sds/Safe Harbor SDS 9.24.pdf
-,Sea Wall,"supplier  (further national methods may be available ): National Institute of Occupational Safety and Health (NIOSH), USA: Manual of Analytical Methods http://www.cdc.gov/niosh/",,2024-09-04,sds/Sea Wall SDS 9.24.pdf
-,Tidal Wave,,,2024-09-04,sds/Tidal Wave SDS 9.24.pdf
-,Tsunami,"Supplier Notification  Xylenes, mixed isomers Ethylbenzene  13330 -20-7 100-41-4 <9.0",,2024-09-04,sds/Tsunami SDS 9.4.24.pdf
-,Typhoon,,,2024-09-04,sds/Typhoon SDS 9.4.24.pdf
-,White Water,,,2024-09-04,sds/White Water SDS 9.4.24.pdf
-,Wipe Out,,,2024-09-04,sds/Wipe Out SDS 9.4.24.pdf
-,"Sizzle Powder Add, Part-A","Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/_sds-sizzle_powder-add-part-a-1_1.pdf
-,Sizzle RTU,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/_sds-sizzle_rtu-1_1.pdf
-,SIZZLE PELS POWDER,"Manufacturer s Address : EaCo Chem, Inc. 765 Commerce Avenue",,2025-04-18,sds/_sds_sizzle_pels_powder-1_1.pdf
+sku,product_name,brand,category,revision_date,link
+,Barrier,,,2020-06-01,[Barrier SDS 6.20.pdf](../Tridentprotects/Barrier/Barrier SDS 6.20.pdf)
+,Break Wall,,,2024-09-04,[Break Wall SDS 9.24.pdf](../Tridentprotects/Break Wall/Break Wall SDS 9.24.pdf)
+,Cyclone,,,2024-09-04,[Cyclone SDS 9.24.pdf](../Tridentprotects/Cyclone/Cyclone SDS 9.24.pdf)
+,Enviro Bio Cleaner Restorer,,,2020-09-03,[EBC-Restore-SDS-September-2020-1.pdf](../Envirobiocleaner/EBC Restorer Restoration Cleaner/EBC-Restore-SDS-September-2020-1.pdf)
+,Hurricane CAT 4 Part A,1-800-537-8990,,2024-09-04,[Hurricane CAT 4 SDS A and B.pdf](../Tridentprotects/Hurricane CAT 4/Hurricane CAT 4 SDS A and B.pdf)
+,Hurricane CAT 5 Part A,1-800-537-8990,,2024-09-04,[Hurricane CAT 5 SDS A and B.pdf](../Tridentprotects/Hurricane CAT 5  Full Kit/Hurricane CAT 5 SDS A and B.pdf)
+,Jetty,,,2024-09-04,[Jetty SDS 9.24.pdf](../Tridentprotects/Jetty/Jetty SDS 9.24.pdf)
+,Point Break,,,2024-09-04,[TDS Point Break.pdf](../Tridentprotects/Point Break/TDS Point Break.pdf)
+,Rip Tide,,,2024-09-04,NOT_FOUND
+,ABF Restoration,,,2025-04-17,[TDS_ABF Restoration.pdf](../Eacochem/ABF Restoration/TDS_ABF Restoration.pdf)
+,Alkaline Stone Cleaner,,,2023-03-30,[SDS-Alkaline-Stone-Cleaner.pdf](../Eacochem/Alkaline Stone Cleaner/SDS-Alkaline-Stone-Cleaner.pdf)
+,Bleach Magic,,,NaT,[SDS-Bleach-Magic.pdf](../Eacochem/Bleach Magic/SDS-Bleach-Magic.pdf)
+,BARC,Product Name:,,2022-03-23,[SDS-F9-BARC-2022.pdf](../Front9restoration/F9 BARC The Best Concrete Rust Remover and Orange Battery Acid Stain Remover/SDS-F9-BARC-2022.pdf)
+,DOUBLE EAGLE,Product Name:,,2022-03-23,[SDS-F9-Double-Eagle-2022.pdf](../Front9restoration/F9 Double Eagle CleanerDegreaserNeutralizerF9 Double Eagle is the first step in the F9 Restoration Process/SDS-F9-Double-Eagle-2022.pdf)
+,EFFLORESCENCE,Product Name:,,2022-03-23,[SDS-F9-Efflorescence-2022.pdf](../Front9restoration/F9 Calcium and Efflorescence RemoverF9 Calcium and Efflorescence Remover is breakthrough in the restoration and cleaning industry/SDS-F9-Efflorescence-2022.pdf)
+,GROUNDSKEEPER,Product Name:,,2022-03-23,[SDS-F9-Groundskeeper-2022.pdf](../Front9restoration/F9 Groundskeeper Industrial Concrete Maintenance CleanerF9 Groundskeeper is our industrial concrete maintenance cleaner/SDS-F9-Groundskeeper-2022.pdf)
+,AcrylicStrip,,,2025-04-17,[SDS_AcrylicStrip.pdf](../Eacochem/AcrylicStrip/SDS_AcrylicStrip.pdf)
+,AP PLUS BC,,,2025-04-17,[SDS_AP_PLUS_BC.pdf](../Eacochem/AP Plus BC/SDS_AP_PLUS_BC.pdf)
+,,,,,[SDS-Bleach-Magic.pdf](../Eacochem/Bleach Magic/SDS-Bleach-Magic.pdf)
+,Cleansol BC,,,2025-04-17,[SDS_Cleansol_BC.pdf](../Eacochem/Cleansol BC/SDS_Cleansol_BC.pdf)
+,C-TAR MELT,,,2025-04-17,[SDS_CTARMELT.pdf](../Eacochem/CTar Melt/SDS_CTARMELT.pdf)
+,CT WASH,,,2025-04-17,[SDS_CT_WASH.pdf](../Eacochem/CT Wash/SDS_CT_WASH.pdf)
+,CALCITE PRESOAK,,,2025-04-17,[SDS_Calcite_Presoak.pdf](../Eacochem/Calcite Presoak/SDS_Calcite_Presoak.pdf)
+,,,,,[SDS-Calcium_Silicate_Cleaner.pdf](../Eacochem/Calcium Silicate Cleaner/SDS-Calcium_Silicate_Cleaner.pdf)
+,DAZZLE BC,,,2025-04-17,[SDS_DAZZLE_BC.pdf](../Eacochem/Dazzle BC/SDS_DAZZLE_BC.pdf)
+,EC 101 WB,,,2017-10-01,[SDS_EC_101_WB.pdf](../Eacochem/EC 101 WB/SDS_EC_101_WB.pdf)
+,EC102 SOL,,,2022-03-28,[SDS_EC_102_SOL.pdf](../Eacochem/EC 102 SOL/SDS_EC_102_SOL.pdf)
+,EF-FORTLESS,,,2025-04-17,[SDS_EF-FORTLESS.pdf](../Eacochem/EFFortless/SDS_EF-FORTLESS.pdf)
+,Glory Truckwash BC,,,2025-04-17,[SDS_GLORY_TW_BC.pdf](../Eacochem/Glory BC/SDS_GLORY_TW_BC.pdf)
+,Graf-Ex,,,2025-04-17,[SDS_GRAFX.pdf](../Eacochem/GrafEx/SDS_GRAFX.pdf)
+,.................... CWB Gold Assassin RTU,.............................. Clean Wash Bay Solutions,,,NOT_FOUND
+,HD Britenol,,,2025-04-17,[SDS_HD_BRITENOL.pdf](../Eacochem/HD Britenol/SDS_HD_BRITENOL.pdf)
+,HD DEGREASER,,,2025-04-17,[SDS_HD_DEGREASER.pdf](../Eacochem/HD Degreaser/SDS_HD_DEGREASER.pdf)
+,HD Sabre,,,2025-04-17,[SDS_HD_SABRE.pdf](../Eacochem/HD Sabre/SDS_HD_SABRE.pdf)
+,Heritage Restorer,,,2025-04-17,[SDS_HERITAGE_RESTORER.pdf](../Eacochem/Heritage Restorer/SDS_HERITAGE_RESTORER.pdf)
+,HOT STAIN REMOVER,,,2025-04-17,[SDS_HOTSTAINREMOVER.pdf](../Eacochem/Hot Stain Remover/SDS_HOTSTAINREMOVER.pdf)
+,InStrip Page: 1 of 7,,,2025-04-17,[SDS_INSTRIP.pdf](../Eacochem/InStrip/SDS_INSTRIP.pdf)
+,LCS,,,2025-04-17,[SDS_LCS.pdf](../Eacochem/LCS/SDS_LCS.pdf)
+,NMD 80,,,2025-04-17,[SDS_NMD80.pdf](../Eacochem/NMD 80/SDS_NMD80.pdf)
+,ONERESTORE,,,2025-04-17,[SDS_ONERESTORE.pdf](../Eacochem/OneRestore/SDS_ONERESTORE.pdf)
+,PLUS,,,2025-04-17,[SDS_PLUS.pdf](../Eacochem/PLUS/SDS_PLUS.pdf)
+,Polished Stone Cleaner,,,2025-04-17,[SDS_POLISHEDSTONECLEANER.pdf](../Eacochem/Polished Stone Cleaner/SDS_POLISHEDSTONECLEANER.pdf)
+,RS-10 BC,,,2025-04-17,[SDS_RS10BC.pdf](../Eacochem/RS 10 BC/SDS_RS10BC.pdf)
+,Sabre II Page: 1 of 7,,,2025-04-18,[SDS_SABRE_2.pdf](../Eacochem/Sabre II/SDS_SABRE_2.pdf)
+,Smoke Melt,,,2025-04-18,[SDS_SMOKE_MELT.pdf](../Eacochem/Smoke Melt/SDS_SMOKE_MELT.pdf)
+,SOS 50,,,2025-04-18,[SDS_SOS50.pdf](../Eacochem/SOS50/SDS_SOS50.pdf)
+,Stripsol LO,,,2025-04-18,[SDS_STRIPSOL_LO.pdf](../Eacochem/Stripsol LO/SDS_STRIPSOL_LO.pdf)
+,Supreme BC,,,2025-04-18,[SDS_SUPREME_BC.pdf](../Eacochem/Supreme BC/SDS_SUPREME_BC.pdf)
+,Stripper Cream,,,2025-04-18,[SDS_Stripper_Cream.pdf](../Eacochem/Stripper Cream/SDS_Stripper_Cream.pdf)
+,TAGAWAYÂ®,,,,NOT_FOUND
+,TAGINATORÂ®,,,,NOT_FOUND
+,WHITE SCUM PRESOAK,,,2025-04-18,[SDS_White-Scum-Presoak-.pdf](../Eacochem/White Scum Presoak/SDS_White-Scum-Presoak-.pdf)
+,,Emergency Telephone Number,,,[SDS_glide-window-cleaning-soap.pdf](../Envirobiocleaner/EBC Glide Window Cleaning Soap/SDS_glide-window-cleaning-soap.pdf)
+,Enviro Bio Cleaner,,,2019-03-09,[SDS_multipurpose-cleaner.pdf](../Envirobiocleaner/EBC Multipurpose Cleaner and Degreaser/SDS_multipurpose-cleaner.pdf)
+,Safe Harbor,,,2024-09-04,[Safe Harbor SDS 9.24.pdf](../Tridentprotects/Safe Harbor/Safe Harbor SDS 9.24.pdf)
+,Sea Wall,,,2024-09-04,[Sea Wall SDS.pdf](../Tridentprotects/Sea Wall/Sea Wall SDS.pdf)
+,Tidal Wave,,,2024-09-04,[TDS Tidal Wave Spray and Gel.pdf](../Tridentprotects/Tidal Wave/TDS Tidal Wave Spray and Gel.pdf)
+,Tsunami,,,2024-09-04,NOT_FOUND
+,Typhoon,,,2024-09-04,NOT_FOUND
+,White Water,,,2024-09-04,NOT_FOUND
+,Wipe Out,,,2024-09-04,NOT_FOUND
+,Sizzle Powder Add,,,2025-04-18,NOT_FOUND
+,Sizzle RTU,,,2025-04-18,NOT_FOUND
+,SIZZLE PELS POWDER,,,2025-04-18,NOT_FOUND


### PR DESCRIPTION
This commit cleans up the `sds.csv` file used to generate the Safety Data Sheet table.

- Corrected the paths to the PDF files, which were previously incorrect.
- Cleaned up the `product_name` and `brand` columns to remove extraneous information.
- Converted the `pdf_path` column into a `link` column with clickable Markdown links to the PDF files.
- The `sds.csv` file is now in a clean and usable state.