### PR TITLE
Fix: Correct GitHub Actions workflow for mkdocs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,21 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      # If this is a Node project; remove if not needed
-      - uses: actions/setup-node@v4
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          node-version: 20
-          cache: 'npm' # change to 'pnpm' or 'yarn' if you use those
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build tables
+        run: python build_tables.py
+      - name: Build site
+        run: mkdocs build
 
-      - run: corepack enable || true
-      - run: npm ci
-      - run: npm run build
-
-      # Upload the build output; adjust the path to your build folder
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist
+          path: ./site
 
   deploy:
     runs-on: ubuntu-latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mkdocs-material
+mkdocs-table-reader-plugin
+pandas


### PR DESCRIPTION
The previous workflow was configured for a Node.js project, causing the deployment to fail. This change replaces the Node.js setup with a Python environment.

- Adds a `requirements.txt` file with the necessary Python packages (`mkdocs`, `mkdocs-material`, `mkdocs-table-reader-plugin`, `pandas`).
- Updates the `.github/workflows/main.yml` to use Python, install dependencies from `requirements.txt`, run the `build_tables.py` script, and build the `mkdocs` site.
- Corrects the artifact path to `./site` to match the `mkdocs` build output.